### PR TITLE
Atualiza versão do biblioteca padrão do kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val mainClassName = "compiler.MainKt"
 repositories { mavenCentral() }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
@@ -23,6 +23,8 @@ kotlin { jvmToolchain(20) }
 application { mainClass = "$mainClassName" }
 
 tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
     manifest { attributes("Main-Class" to "$mainClassName") }
 
     from(sourceSets.main.get().output)


### PR DESCRIPTION
Algumas da funções da biblioteca de Regex não estavam disponível, por exemplo a função `matchAt`, que será útil para a escrita do lexer. Descobri que o problema é devido a versão da biblioteca do kotlin, atualizei a mesma e adicionei o trecho `duplicatesStrategy = DuplicatesStrategy.EXCLUDE`, isso foi necessário para resolver problemas na geração do Jar que apareceram depois da atualização, mais detalhes é descrito no link: https://stackoverflow.com/questions/67265308/gradle-entry-classpath-is-a-duplicate-but-no-duplicate-handling-strategy-has-b